### PR TITLE
Corrects issue with base path duplicating

### DIFF
--- a/scripts/docker/buildAll.cmd
+++ b/scripts/docker/buildAll.cmd
@@ -1,0 +1,4 @@
+@REM runs all scripts start to finish, using docker where windows might be an issue
+echo Fetching and Manipulating spec...
+.\scripts\docker\buildSpec.cmd && npm run openapi && .\scripts\docker\runPkg.cmd && cd cwmsjs && npm install && npm run build && cd ..
+echo Done.

--- a/scripts/docker/buildSpec.cmd
+++ b/scripts/docker/buildSpec.cmd
@@ -1,0 +1,2 @@
+@REM Run scripts from windows
+docker run --rm -v %cd%:/scripts -w /scripts node:lts bash -c "npm install -g node-jq && npm run buildSpec"

--- a/scripts/docker/runPkg.cmd
+++ b/scripts/docker/runPkg.cmd
@@ -1,0 +1,1 @@
+docker run --rm -v %cd%:/scripts -w /scripts node:lts bash -c "npm install -g node-jq && npm run modPackage"

--- a/scripts/spec-updates/modSpec.sh
+++ b/scripts/spec-updates/modSpec.sh
@@ -42,5 +42,10 @@ sed -r 's/"(get|post|patch|put|delete)CwmsData(\w*)"/"\1\2"/g' |
 # Change casing of "Timeseries" to "TimeSeries"
 sed -r 's/Timeseries/TimeSeries/g' |
 
+# Remove the /cwms-data base path on all endpoints so user can use their own
+sed -r 's|"/cwms-data|"/|g' |
+# Remove extra slashes
+sed -r 's|"//|"/|g'  > cwms-swagger-mod.json |
+
 # Write to file
 cat > cwms-swagger-mod.json

--- a/scripts/spec-updates/servers.json
+++ b/scripts/spec-updates/servers.json
@@ -1,11 +1,11 @@
 {
   "servers": [
     {
-      "url": "https://cwms-data.usace.army.mil",
+      "url": "https://cwms-data.usace.army.mil/cwms-data",
       "description": "PRIMARY production server"
     },
     {
-      "url": "https://water.usace.army.mil",
+      "url": "https://water.usace.army.mil/cwms-data",
       "description": "Alias for the PRIMARY production server"
     }
   ]

--- a/tests/endpoints/TimeSeries.v2.test.js
+++ b/tests/endpoints/TimeSeries.v2.test.js
@@ -12,11 +12,19 @@ test("Test TimeSeries V2", async () => {
   });
   const ts_api = new TimeSeriesApi(v2_config);
   await ts_api
-    .getTimeSeries({
+    .getTimeSeriesRaw({
       office: "SWT",
       name: "KEYS.Elev.Inst.1Hour.0.Ccp-Rev",
     })
+    .then((r) => {
+      console.log(r.raw.url);
+      return r.raw.json();
+    })
     .then((data) => {
       expect(data?.values).toBeDefined();
+    })
+    .catch((e) => {
+      console.log(e);
+      throw Error(e);
     });
 }, 30000);

--- a/tests/package.json
+++ b/tests/package.json
@@ -16,6 +16,7 @@
         "test": "npm run jest-modules --",
         "test-cicd": "npm run jest-modules -- --runInBand --ci --detectOpenHandles",
         "coverage": "npm run test --coverage",
+        "test:ts": "npm run jest-modules Timeseries.v2.test.js",
         "link": "cd ../src && npm link && cd ../tests && npm link cwmsjs"
     },
     "jest": {


### PR DESCRIPTION
This resolves issue #15

- Additional docker scripts were made to help run these build/manipulation scripts on Windows/various platforms. 
- Altered the spec manipulation script to remove basePaths from the endpoints and allow endusers to override this. 


